### PR TITLE
Group courses with prerequisites and fix arrow overflow

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,8 +8,13 @@
                 font-family: sans-serif;
                 margin: 20px;
             }
+            .group {
+                display: inline-block;
+                margin: 20px;
+            }
             .row {
-                margin-bottom: 40px;
+                margin-bottom: 10px;
+                text-align: center;
                 white-space: nowrap;
             }
             .node {
@@ -24,9 +29,8 @@
                 position: absolute;
                 top: 0;
                 left: 0;
-                width: 100%;
-                height: 100%;
                 pointer-events: none;
+                overflow: visible;
             }
         </style>
     </head>
@@ -50,45 +54,35 @@
                     prereqs: parsePrereqs(c.prereq_text),
                 }));
 
-                const placed = new Map();
-                const levels = [];
-                while (nodes.length) {
-                    const level = nodes.filter((n) =>
-                        n.prereqs.every((p) => placed.has(p))
-                    );
-                    if (level.length === 0) {
-                        level.push(...nodes); // break cycle if any
-                    }
-                    levels.push(level);
-                    level.forEach((n) => placed.set(n.code, levels.length - 1));
-                    for (const n of level) {
-                        const idx = nodes.indexOf(n);
-                        if (idx !== -1) nodes.splice(idx, 1);
-                    }
-                }
-
                 const tree = d3.select("#tree");
-                levels.forEach((level, i) => {
-                    const row = tree
-                        .append("div")
-                        .attr("class", "row")
-                        .attr("data-level", i);
-                    level.forEach((node) => {
-                        row.append("div")
+                nodes.forEach((node, i) => {
+                    const group = tree.append("div").attr("class", "group");
+
+                    const prereqRow = group.append("div").attr("class", "row prereqs");
+                    node.prereqs.forEach((pr) => {
+                        prereqRow
+                            .append("div")
                             .attr("class", "node")
-                            .attr("id", node.code.replace(/\./g, "_"))
-                            .style("background", node.color)
-                            .text(node.code);
+                            .attr("id", `g${i}_` + pr.replace(/\./g, "_"))
+                            .text(pr);
                     });
+
+                    const courseRow = group.append("div").attr("class", "row course");
+                    courseRow
+                        .append("div")
+                        .attr("class", "node")
+                        .attr("id", `g${i}_` + node.code.replace(/\./g, "_"))
+                        .style("background", node.color)
+                        .text(node.code);
                 });
 
-                drawLines(levels);
+                drawLines(nodes);
             }
 
-            function drawLines(levels) {
+            function drawLines(nodes) {
                 const svg = d3.select("#lines");
-                svg.attr("width", document.body.scrollWidth);
-                svg.attr("height", document.body.scrollHeight);
+                svg.attr("width", document.documentElement.scrollWidth);
+                svg.attr("height", document.documentElement.scrollHeight);
                 const defs = svg.append("defs");
                 defs.append("marker")
                     .attr("id", "arrow")
@@ -102,26 +96,24 @@
                     .attr("d", "M0,-5L10,0L0,5")
                     .attr("fill", "#999");
 
-                levels.forEach((level) => {
-                    level.forEach((node) => {
-                        const el = document.getElementById(
-                            node.code.replace(/\./g, "_")
+                nodes.forEach((node, i) => {
+                    const el = document.getElementById(
+                        `g${i}_` + node.code.replace(/\./g, "_")
+                    );
+                    const rect = el.getBoundingClientRect();
+                    node.prereqs.forEach((pr) => {
+                        const pe = document.getElementById(
+                            `g${i}_` + pr.replace(/\./g, "_")
                         );
-                        const rect = el.getBoundingClientRect();
-                        node.prereqs.forEach((pr) => {
-                            const pe = document.getElementById(
-                                pr.replace(/\./g, "_")
-                            );
-                            if (!pe) return;
-                            const prect = pe.getBoundingClientRect();
-                            svg.append("line")
-                                .attr("x1", prect.left + prect.width / 2)
-                                .attr("y1", prect.bottom)
-                                .attr("x2", rect.left + rect.width / 2)
-                                .attr("y2", rect.top)
-                                .attr("stroke", "#999")
-                                .attr("marker-end", "url(#arrow)");
-                        });
+                        if (!pe) return;
+                        const prect = pe.getBoundingClientRect();
+                        svg.append("line")
+                            .attr("x1", prect.left + prect.width / 2)
+                            .attr("y1", prect.bottom)
+                            .attr("x2", rect.left + rect.width / 2)
+                            .attr("y2", rect.top)
+                            .attr("stroke", "#999")
+                            .attr("marker-end", "url(#arrow)");
                     });
                 });
             }

--- a/index.html
+++ b/index.html
@@ -8,149 +8,25 @@
                 font-family: sans-serif;
                 margin: 20px;
             }
-            .row {
-                margin-bottom: 40px;
-                white-space: nowrap;
-            }
-            .node {
-                display: inline-block;
-                padding: 4px 8px;
-                margin: 4px;
-                border: 1px solid #999;
-                border-radius: 4px;
-                background: #f9f9f9;
-                transition: background 0.2s, border-color 0.2s;
-            }
-            .node.active {
-                background: #ffd;
-                border-color: #333;
-            }
             svg {
-                position: absolute;
-                top: 0;
-                left: 0;
-                pointer-events: none;
                 overflow: visible;
+            }
+            .node rect {
+                stroke: #999;
+                fill: var(--node-color, #f9f9f9);
+                transition: fill 0.2s, stroke 0.2s;
+            }
+            .node.active rect {
+                fill: #ffd;
+                stroke: #333;
             }
         </style>
     </head>
     <body>
         <h1>MIT Class Tech Tree</h1>
-        <div id="tree"></div>
-        <svg id="lines"></svg>
+        <svg id="tree"></svg>
         <script src="https://cdnjs.cloudflare.com/ajax/libs/d3/7.8.4/d3.min.js"></script>
-        <script>
-            function parsePrereqs(txt) {
-                if (!txt) return [];
-                const matches = txt.match(/\b\d{1,2}\.\d+[A-Z]*\b/g);
-                return matches ? matches : [];
-            }
-
-            function buildTree(data) {
-                const nodes = Object.values(data).map((c) => ({
-                    code: c.code,
-                    title: c.title,
-                    color: c.color || "#f9f9f9",
-                    prereqs: parsePrereqs(c.prereq_text),
-                }));
-
-                const placed = new Map();
-                const levels = [];
-                while (nodes.length) {
-                    const level = nodes.filter((n) =>
-                        n.prereqs.every((p) => placed.has(p))
-                    );
-                    if (level.length === 0) {
-                        level.push(...nodes); // break cycle if any
-                    }
-                    levels.push(level);
-                    level.forEach((n) => placed.set(n.code, levels.length - 1));
-                    for (const n of level) {
-                        const idx = nodes.indexOf(n);
-                        if (idx !== -1) nodes.splice(idx, 1);
-                    }
-                }
-
-                const tree = d3.select("#tree");
-                levels.forEach((level, i) => {
-                    const row = tree
-                        .append("div")
-                        .attr("class", "row")
-                        .attr("data-level", i);
-                    level.forEach((node) => {
-                        const nodeEl = row
-                            .append("div")
-                            .attr("class", "node")
-                            .attr("id", node.code.replace(/\./g, "_"))
-                            .style("background", node.color)
-                            .text(node.code);
-
-                        nodeEl.on("mouseover", () => {
-                            nodeEl.classed("active", true);
-                            node.prereqs.forEach((pr) => {
-                                d3.select(`#${pr.replace(/\./g, "_")}`).classed(
-                                    "active",
-                                    true
-                                );
-                            });
-                        });
-                        nodeEl.on("mouseout", () => {
-                            d3.selectAll(".node").classed("active", false);
-                        });
-                    });
-                });
-
-                drawLines(levels);
-            }
-
-            function drawLines(levels) {
-                const svg = d3.select("#lines");
-                svg.attr("width", document.documentElement.scrollWidth);
-                svg.attr("height", document.documentElement.scrollHeight);
-                const defs = svg.append("defs");
-                defs.append("marker")
-                    .attr("id", "arrow")
-                    .attr("viewBox", "0 -5 10 10")
-                    .attr("refX", 8)
-                    .attr("refY", 0)
-                    .attr("markerWidth", 6)
-                    .attr("markerHeight", 6)
-                    .attr("orient", "auto")
-                    .append("path")
-                    .attr("d", "M0,-5L10,0L0,5")
-                    .attr("fill", "#999");
-
-                levels.forEach((level) => {
-                    level.forEach((node) => {
-                        const el = document.getElementById(
-                            node.code.replace(/\./g, "_")
-                        );
-                        const rect = el.getBoundingClientRect();
-                        node.prereqs.forEach((pr) => {
-                            const pe = document.getElementById(
-                                pr.replace(/\./g, "_")
-                            );
-                            if (!pe) return;
-                            const prect = pe.getBoundingClientRect();
-                            svg.append("line")
-                                .attr("x1", prect.left + prect.width / 2)
-                                .attr("y1", prect.bottom)
-                                .attr("x2", rect.left + rect.width / 2)
-                                .attr("y2", rect.top)
-                                .attr("stroke", "#999")
-                                .attr("marker-end", "url(#arrow)");
-                        });
-                    });
-                });
-            }
-
-            fetch("classes.json")
-                .then((r) => r.json())
-                .then(buildTree)
-                .catch((err) => {
-                    document.getElementById("tree").innerText =
-                        "Failed to load classes.json: " + err;
-                });
-        </script>
+        <script src="https://unpkg.com/dagre-d3@0.6.4/dist/dagre-d3.min.js"></script>
+        <script src="tree.js"></script>
     </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -8,13 +8,8 @@
                 font-family: sans-serif;
                 margin: 20px;
             }
-            .group {
-                display: inline-block;
-                margin: 20px;
-            }
             .row {
-                margin-bottom: 10px;
-                text-align: center;
+                margin-bottom: 40px;
                 white-space: nowrap;
             }
             .node {
@@ -24,6 +19,11 @@
                 border: 1px solid #999;
                 border-radius: 4px;
                 background: #f9f9f9;
+                transition: background 0.2s, border-color 0.2s;
+            }
+            .node.active {
+                background: #ffd;
+                border-color: #333;
             }
             svg {
                 position: absolute;
@@ -54,32 +54,56 @@
                     prereqs: parsePrereqs(c.prereq_text),
                 }));
 
-                const tree = d3.select("#tree");
-                nodes.forEach((node, i) => {
-                    const group = tree.append("div").attr("class", "group");
+                const placed = new Map();
+                const levels = [];
+                while (nodes.length) {
+                    const level = nodes.filter((n) =>
+                        n.prereqs.every((p) => placed.has(p))
+                    );
+                    if (level.length === 0) {
+                        level.push(...nodes); // break cycle if any
+                    }
+                    levels.push(level);
+                    level.forEach((n) => placed.set(n.code, levels.length - 1));
+                    for (const n of level) {
+                        const idx = nodes.indexOf(n);
+                        if (idx !== -1) nodes.splice(idx, 1);
+                    }
+                }
 
-                    const prereqRow = group.append("div").attr("class", "row prereqs");
-                    node.prereqs.forEach((pr) => {
-                        prereqRow
+                const tree = d3.select("#tree");
+                levels.forEach((level, i) => {
+                    const row = tree
+                        .append("div")
+                        .attr("class", "row")
+                        .attr("data-level", i);
+                    level.forEach((node) => {
+                        const nodeEl = row
                             .append("div")
                             .attr("class", "node")
-                            .attr("id", `g${i}_` + pr.replace(/\./g, "_"))
-                            .text(pr);
-                    });
+                            .attr("id", node.code.replace(/\./g, "_"))
+                            .style("background", node.color)
+                            .text(node.code);
 
-                    const courseRow = group.append("div").attr("class", "row course");
-                    courseRow
-                        .append("div")
-                        .attr("class", "node")
-                        .attr("id", `g${i}_` + node.code.replace(/\./g, "_"))
-                        .style("background", node.color)
-                        .text(node.code);
+                        nodeEl.on("mouseover", () => {
+                            nodeEl.classed("active", true);
+                            node.prereqs.forEach((pr) => {
+                                d3.select(`#${pr.replace(/\./g, "_")}`).classed(
+                                    "active",
+                                    true
+                                );
+                            });
+                        });
+                        nodeEl.on("mouseout", () => {
+                            d3.selectAll(".node").classed("active", false);
+                        });
+                    });
                 });
 
-                drawLines(nodes);
+                drawLines(levels);
             }
 
-            function drawLines(nodes) {
+            function drawLines(levels) {
                 const svg = d3.select("#lines");
                 svg.attr("width", document.documentElement.scrollWidth);
                 svg.attr("height", document.documentElement.scrollHeight);
@@ -96,24 +120,26 @@
                     .attr("d", "M0,-5L10,0L0,5")
                     .attr("fill", "#999");
 
-                nodes.forEach((node, i) => {
-                    const el = document.getElementById(
-                        `g${i}_` + node.code.replace(/\./g, "_")
-                    );
-                    const rect = el.getBoundingClientRect();
-                    node.prereqs.forEach((pr) => {
-                        const pe = document.getElementById(
-                            `g${i}_` + pr.replace(/\./g, "_")
+                levels.forEach((level) => {
+                    level.forEach((node) => {
+                        const el = document.getElementById(
+                            node.code.replace(/\./g, "_")
                         );
-                        if (!pe) return;
-                        const prect = pe.getBoundingClientRect();
-                        svg.append("line")
-                            .attr("x1", prect.left + prect.width / 2)
-                            .attr("y1", prect.bottom)
-                            .attr("x2", rect.left + rect.width / 2)
-                            .attr("y2", rect.top)
-                            .attr("stroke", "#999")
-                            .attr("marker-end", "url(#arrow)");
+                        const rect = el.getBoundingClientRect();
+                        node.prereqs.forEach((pr) => {
+                            const pe = document.getElementById(
+                                pr.replace(/\./g, "_")
+                            );
+                            if (!pe) return;
+                            const prect = pe.getBoundingClientRect();
+                            svg.append("line")
+                                .attr("x1", prect.left + prect.width / 2)
+                                .attr("y1", prect.bottom)
+                                .attr("x2", rect.left + rect.width / 2)
+                                .attr("y2", rect.top)
+                                .attr("stroke", "#999")
+                                .attr("marker-end", "url(#arrow)");
+                        });
                     });
                 });
             }

--- a/tech_tree.html
+++ b/tech_tree.html
@@ -5,7 +5,15 @@
   <title>MIT Class Tech Tree</title>
   <style>
     body { font-family: sans-serif; margin: 20px; }
-    .row { margin-bottom: 40px; white-space: nowrap; }
+    .group {
+      display: inline-block;
+      margin: 20px;
+    }
+    .row {
+      margin-bottom: 10px;
+      text-align: center;
+      white-space: nowrap;
+    }
     .node {
       display: inline-block;
       padding: 4px 8px;
@@ -18,9 +26,8 @@
       position: absolute;
       top: 0;
       left: 0;
-      width: 100%;
-      height: 100%;
       pointer-events: none;
+      overflow: visible;
     }
   </style>
 </head>
@@ -44,40 +51,33 @@
         prereqs: parsePrereqs(c.prereq_text)
       }));
 
-      const placed = new Map();
-      const levels = [];
-      while (nodes.length) {
-        const level = nodes.filter(n => n.prereqs.every(p => placed.has(p)));
-        if (level.length === 0) {
-          level.push(...nodes); // break cycle if any
-        }
-        levels.push(level);
-        level.forEach(n => placed.set(n.code, levels.length - 1));
-        for (const n of level) {
-          const idx = nodes.indexOf(n);
-          if (idx !== -1) nodes.splice(idx, 1);
-        }
-      }
-
       const tree = d3.select('#tree');
-      levels.forEach((level, i) => {
-        const row = tree.append('div').attr('class', 'row').attr('data-level', i);
-        level.forEach(node => {
-          row.append('div')
+      nodes.forEach((node, i) => {
+        const group = tree.append('div').attr('class', 'group');
+
+        const prereqRow = group.append('div').attr('class', 'row prereqs');
+        node.prereqs.forEach(pr => {
+          prereqRow.append('div')
             .attr('class', 'node')
-            .attr('id', node.code.replace(/\./g, '_'))
-            .style('background', node.color)
-            .text(node.code);
+            .attr('id', `g${i}_` + pr.replace(/\./g, '_'))
+            .text(pr);
         });
+
+        const courseRow = group.append('div').attr('class', 'row course');
+        courseRow.append('div')
+          .attr('class', 'node')
+          .attr('id', `g${i}_` + node.code.replace(/\./g, '_'))
+          .style('background', node.color)
+          .text(node.code);
       });
 
-      drawLines(levels);
+      drawLines(nodes);
     }
 
-    function drawLines(levels) {
+    function drawLines(nodes) {
       const svg = d3.select('#lines');
-      svg.attr('width', document.body.scrollWidth);
-      svg.attr('height', document.body.scrollHeight);
+      svg.attr('width', document.documentElement.scrollWidth);
+      svg.attr('height', document.documentElement.scrollHeight);
       const defs = svg.append('defs');
       defs.append('marker')
         .attr('id', 'arrow')
@@ -91,22 +91,20 @@
         .attr('d', 'M0,-5L10,0L0,5')
         .attr('fill', '#999');
 
-      levels.forEach(level => {
-        level.forEach(node => {
-          const el = document.getElementById(node.code.replace(/\./g, '_'));
-          const rect = el.getBoundingClientRect();
-          node.prereqs.forEach(pr => {
-            const pe = document.getElementById(pr.replace(/\./g, '_'));
-            if (!pe) return;
-            const prect = pe.getBoundingClientRect();
-            svg.append('line')
-              .attr('x1', prect.left + prect.width / 2)
-              .attr('y1', prect.bottom)
-              .attr('x2', rect.left + rect.width / 2)
-              .attr('y2', rect.top)
-              .attr('stroke', '#999')
-              .attr('marker-end', 'url(#arrow)');
-          });
+      nodes.forEach((node, i) => {
+        const el = document.getElementById(`g${i}_` + node.code.replace(/\./g, '_'));
+        const rect = el.getBoundingClientRect();
+        node.prereqs.forEach(pr => {
+          const pe = document.getElementById(`g${i}_` + pr.replace(/\./g, '_'));
+          if (!pe) return;
+          const prect = pe.getBoundingClientRect();
+          svg.append('line')
+            .attr('x1', prect.left + prect.width / 2)
+            .attr('y1', prect.bottom)
+            .attr('x2', rect.left + rect.width / 2)
+            .attr('y2', rect.top)
+            .attr('stroke', '#999')
+            .attr('marker-end', 'url(#arrow)');
         });
       });
     }

--- a/tech_tree.html
+++ b/tech_tree.html
@@ -5,15 +5,7 @@
   <title>MIT Class Tech Tree</title>
   <style>
     body { font-family: sans-serif; margin: 20px; }
-    .group {
-      display: inline-block;
-      margin: 20px;
-    }
-    .row {
-      margin-bottom: 10px;
-      text-align: center;
-      white-space: nowrap;
-    }
+    .row { margin-bottom: 40px; white-space: nowrap; }
     .node {
       display: inline-block;
       padding: 4px 8px;
@@ -21,7 +13,9 @@
       border: 1px solid #999;
       border-radius: 4px;
       background: #f9f9f9;
+      transition: background 0.2s, border-color 0.2s;
     }
+    .node.active { background: #ffd; border-color: #333; }
     svg {
       position: absolute;
       top: 0;
@@ -51,30 +45,47 @@
         prereqs: parsePrereqs(c.prereq_text)
       }));
 
+      const placed = new Map();
+      const levels = [];
+      while (nodes.length) {
+        const level = nodes.filter(n => n.prereqs.every(p => placed.has(p)));
+        if (level.length === 0) {
+          level.push(...nodes); // break cycle if any
+        }
+        levels.push(level);
+        level.forEach(n => placed.set(n.code, levels.length - 1));
+        for (const n of level) {
+          const idx = nodes.indexOf(n);
+          if (idx !== -1) nodes.splice(idx, 1);
+        }
+      }
+
       const tree = d3.select('#tree');
-      nodes.forEach((node, i) => {
-        const group = tree.append('div').attr('class', 'group');
-
-        const prereqRow = group.append('div').attr('class', 'row prereqs');
-        node.prereqs.forEach(pr => {
-          prereqRow.append('div')
+      levels.forEach((level, i) => {
+        const row = tree.append('div').attr('class', 'row').attr('data-level', i);
+        level.forEach(node => {
+          const nodeEl = row.append('div')
             .attr('class', 'node')
-            .attr('id', `g${i}_` + pr.replace(/\./g, '_'))
-            .text(pr);
-        });
+            .attr('id', node.code.replace(/\./g, '_'))
+            .style('background', node.color)
+            .text(node.code);
 
-        const courseRow = group.append('div').attr('class', 'row course');
-        courseRow.append('div')
-          .attr('class', 'node')
-          .attr('id', `g${i}_` + node.code.replace(/\./g, '_'))
-          .style('background', node.color)
-          .text(node.code);
+          nodeEl.on('mouseover', () => {
+            nodeEl.classed('active', true);
+            node.prereqs.forEach(pr => {
+              d3.select(`#${pr.replace(/\./g, '_')}`).classed('active', true);
+            });
+          });
+          nodeEl.on('mouseout', () => {
+            d3.selectAll('.node').classed('active', false);
+          });
+        });
       });
 
-      drawLines(nodes);
+      drawLines(levels);
     }
 
-    function drawLines(nodes) {
+    function drawLines(levels) {
       const svg = d3.select('#lines');
       svg.attr('width', document.documentElement.scrollWidth);
       svg.attr('height', document.documentElement.scrollHeight);
@@ -91,20 +102,22 @@
         .attr('d', 'M0,-5L10,0L0,5')
         .attr('fill', '#999');
 
-      nodes.forEach((node, i) => {
-        const el = document.getElementById(`g${i}_` + node.code.replace(/\./g, '_'));
-        const rect = el.getBoundingClientRect();
-        node.prereqs.forEach(pr => {
-          const pe = document.getElementById(`g${i}_` + pr.replace(/\./g, '_'));
-          if (!pe) return;
-          const prect = pe.getBoundingClientRect();
-          svg.append('line')
-            .attr('x1', prect.left + prect.width / 2)
-            .attr('y1', prect.bottom)
-            .attr('x2', rect.left + rect.width / 2)
-            .attr('y2', rect.top)
-            .attr('stroke', '#999')
-            .attr('marker-end', 'url(#arrow)');
+      levels.forEach(level => {
+        level.forEach(node => {
+          const el = document.getElementById(node.code.replace(/\./g, '_'));
+          const rect = el.getBoundingClientRect();
+          node.prereqs.forEach(pr => {
+            const pe = document.getElementById(pr.replace(/\./g, '_'));
+            if (!pe) return;
+            const prect = pe.getBoundingClientRect();
+            svg.append('line')
+              .attr('x1', prect.left + prect.width / 2)
+              .attr('y1', prect.bottom)
+              .attr('x2', rect.left + rect.width / 2)
+              .attr('y2', rect.top)
+              .attr('stroke', '#999')
+              .attr('marker-end', 'url(#arrow)');
+          });
         });
       });
     }

--- a/tech_tree.html
+++ b/tech_tree.html
@@ -5,129 +5,20 @@
   <title>MIT Class Tech Tree</title>
   <style>
     body { font-family: sans-serif; margin: 20px; }
-    .row { margin-bottom: 40px; white-space: nowrap; }
-    .node {
-      display: inline-block;
-      padding: 4px 8px;
-      margin: 4px;
-      border: 1px solid #999;
-      border-radius: 4px;
-      background: #f9f9f9;
-      transition: background 0.2s, border-color 0.2s;
+    svg { overflow: visible; }
+    .node rect {
+      stroke: #999;
+      fill: var(--node-color, #f9f9f9);
+      transition: fill 0.2s, stroke 0.2s;
     }
-    .node.active { background: #ffd; border-color: #333; }
-    svg {
-      position: absolute;
-      top: 0;
-      left: 0;
-      pointer-events: none;
-      overflow: visible;
-    }
+    .node.active rect { fill: #ffd; stroke: #333; }
   </style>
 </head>
 <body>
   <h1>MIT Class Tech Tree</h1>
-  <div id="tree"></div>
-  <svg id="lines"></svg>
+  <svg id="tree"></svg>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/d3/7.8.4/d3.min.js"></script>
-  <script>
-    function parsePrereqs(txt) {
-      if (!txt) return [];
-      const matches = txt.match(/\b\d{1,2}\.\d+[A-Z]*\b/g);
-      return matches ? matches : [];
-    }
-
-    function buildTree(data) {
-      const nodes = Object.values(data).map(c => ({
-        code: c.code,
-        title: c.title,
-        color: c.color || '#f9f9f9',
-        prereqs: parsePrereqs(c.prereq_text)
-      }));
-
-      const placed = new Map();
-      const levels = [];
-      while (nodes.length) {
-        const level = nodes.filter(n => n.prereqs.every(p => placed.has(p)));
-        if (level.length === 0) {
-          level.push(...nodes); // break cycle if any
-        }
-        levels.push(level);
-        level.forEach(n => placed.set(n.code, levels.length - 1));
-        for (const n of level) {
-          const idx = nodes.indexOf(n);
-          if (idx !== -1) nodes.splice(idx, 1);
-        }
-      }
-
-      const tree = d3.select('#tree');
-      levels.forEach((level, i) => {
-        const row = tree.append('div').attr('class', 'row').attr('data-level', i);
-        level.forEach(node => {
-          const nodeEl = row.append('div')
-            .attr('class', 'node')
-            .attr('id', node.code.replace(/\./g, '_'))
-            .style('background', node.color)
-            .text(node.code);
-
-          nodeEl.on('mouseover', () => {
-            nodeEl.classed('active', true);
-            node.prereqs.forEach(pr => {
-              d3.select(`#${pr.replace(/\./g, '_')}`).classed('active', true);
-            });
-          });
-          nodeEl.on('mouseout', () => {
-            d3.selectAll('.node').classed('active', false);
-          });
-        });
-      });
-
-      drawLines(levels);
-    }
-
-    function drawLines(levels) {
-      const svg = d3.select('#lines');
-      svg.attr('width', document.documentElement.scrollWidth);
-      svg.attr('height', document.documentElement.scrollHeight);
-      const defs = svg.append('defs');
-      defs.append('marker')
-        .attr('id', 'arrow')
-        .attr('viewBox', '0 -5 10 10')
-        .attr('refX', 8)
-        .attr('refY', 0)
-        .attr('markerWidth', 6)
-        .attr('markerHeight', 6)
-        .attr('orient', 'auto')
-        .append('path')
-        .attr('d', 'M0,-5L10,0L0,5')
-        .attr('fill', '#999');
-
-      levels.forEach(level => {
-        level.forEach(node => {
-          const el = document.getElementById(node.code.replace(/\./g, '_'));
-          const rect = el.getBoundingClientRect();
-          node.prereqs.forEach(pr => {
-            const pe = document.getElementById(pr.replace(/\./g, '_'));
-            if (!pe) return;
-            const prect = pe.getBoundingClientRect();
-            svg.append('line')
-              .attr('x1', prect.left + prect.width / 2)
-              .attr('y1', prect.bottom)
-              .attr('x2', rect.left + rect.width / 2)
-              .attr('y2', rect.top)
-              .attr('stroke', '#999')
-              .attr('marker-end', 'url(#arrow)');
-          });
-        });
-      });
-    }
-
-    fetch('classes.json')
-      .then(r => r.json())
-      .then(buildTree)
-      .catch(err => {
-        document.getElementById('tree').innerText = 'Failed to load classes.json: ' + err;
-      });
-  </script>
+  <script src="https://unpkg.com/dagre-d3@0.6.4/dist/dagre-d3.min.js"></script>
+  <script src="tree.js"></script>
 </body>
 </html>

--- a/tree.js
+++ b/tree.js
@@ -23,7 +23,7 @@ function buildGraph(data) {
         parsePrereqs(c.prereq_text).forEach(pr => {
             const source = nodeId(pr);
             if (courseMap[source]) {
-                g.setEdge(source, target);
+                g.setEdge(source, target, {});
             }
         });
     });

--- a/tree.js
+++ b/tree.js
@@ -1,0 +1,64 @@
+function parsePrereqs(txt) {
+    if (!txt) return [];
+    const matches = txt.match(/\b\d{1,2}\.\d+[A-Z]*\b/g);
+    return matches || [];
+}
+
+function nodeId(code) {
+    return code.replace(/\./g, '_');
+}
+
+function buildGraph(data) {
+    const g = new dagreD3.graphlib.Graph().setGraph({ ranksep: 50, nodesep: 30, edgesep: 20 });
+    const courseMap = {};
+
+    Object.values(data).forEach(c => {
+        const id = nodeId(c.code);
+        courseMap[id] = c;
+        g.setNode(id, { label: c.code });
+    });
+
+    Object.values(data).forEach(c => {
+        const target = nodeId(c.code);
+        parsePrereqs(c.prereq_text).forEach(pr => {
+            const source = nodeId(pr);
+            if (courseMap[source]) {
+                g.setEdge(source, target);
+            }
+        });
+    });
+
+    const render = new dagreD3.render();
+    const svg = d3.select('#tree');
+    const svgGroup = svg.append('g');
+    render(svgGroup, g);
+
+    svg.attr('width', g.graph().width + 40);
+    svg.attr('height', g.graph().height + 40);
+    svgGroup.attr('transform', 'translate(20,20)');
+
+    svgGroup.selectAll('g.node').each(function(id) {
+        const color = courseMap[id].color || '#f9f9f9';
+        d3.select(this).select('rect').style('--node-color', color);
+    });
+
+    svgGroup.selectAll('g.node')
+        .on('mouseover', function(event, id) {
+            d3.select(this).classed('active', true);
+            const prereqs = parsePrereqs(courseMap[id].prereq_text);
+            prereqs.forEach(pr => {
+                const pid = nodeId(pr);
+                svgGroup.select(`#${pid}`).classed('active', true);
+            });
+        })
+        .on('mouseout', function() {
+            svgGroup.selectAll('g.node').classed('active', false);
+        });
+}
+
+fetch('classes.json')
+    .then(r => r.json())
+    .then(buildGraph)
+    .catch(err => {
+        d3.select('body').append('p').text('Failed to load classes.json: ' + err);
+    });


### PR DESCRIPTION
## Summary
- Group each course with its immediate prerequisites to keep related nodes together
- Resize SVG dynamically and allow overflow so arrowheads remain visible outside the initial view

## Testing
- `python -m py_compile scrape_mit_catalog.py`


------
https://chatgpt.com/codex/tasks/task_e_68aa4032f9d8832dbb665aaad8964578